### PR TITLE
Fix prototype pollution

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "printWidth": 100,
+    "tabWidth": 4,
+    "singleQuote": true,
+    "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-ini",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "description": "An ini-file parser which supports multi line, multiple levels and arrays to get a maximum of compatibility with Zend config files.",
   "main": "lib/index.js",

--- a/test/data/prototype_pollution.ini
+++ b/test/data/prototype_pollution.ini
@@ -1,0 +1,6 @@
+[test]
+value=key
+[__proto__]
+polluted="polluted"
+[other]
+__proto__.path_polluted="polluted"

--- a/test/filter_spec.js
+++ b/test/filter_spec.js
@@ -1,108 +1,114 @@
-'use strict';
+"use strict";
 
-const chai = require('chai');
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
+const chai = require("chai");
+const sinon = require("sinon");
+const sinonChai = require("sinon-chai");
 const expect = chai.expect;
 
 chai.use(sinonChai);
 
 describe("Filters", function () {
-    var MultiIni = require('../src');
+  var MultiIni = require("../src");
 
-    it("Availability of the filters", function () {
-        expect(MultiIni.filters).not.to.be.undefined;
-        expect(MultiIni.filters).not.to.be.null;
+  it("Availability of the filters", function () {
+    expect(MultiIni.filters).not.to.be.undefined;
+    expect(MultiIni.filters).not.to.be.null;
+  });
+
+  describe("lowercase", function () {
+    it("is available", function () {
+      expect(MultiIni.filters.lowercase).to.be.defined;
     });
 
-    describe("lowercase", function () {
-        it("is available", function () {
-            expect(MultiIni.filters.lowercase).to.be.defined;
-        });
-
-        it("string should be lowercase", function () {
-            expect(MultiIni.filters.lowercase('Test')).to.equal('test');
-        });
-
-        it("anything else then string will be returned unmodified", function () {
-            expect(MultiIni.filters.lowercase(false)).to.equal(false);
-        });
+    it("string should be lowercase", function () {
+      expect(MultiIni.filters.lowercase("Test")).to.equal("test");
     });
 
-    describe("uppercase", function () {
-        it("is available", function () {
-            expect(MultiIni.filters.uppercase).to.be.defined;
-        });
+    it("anything else then string will be returned unmodified", function () {
+      expect(MultiIni.filters.lowercase(false)).to.equal(false);
+    });
+  });
 
-        it("string should be uppercase", function () {
-            expect(MultiIni.filters.uppercase('Test')).to.equal('TEST');
-        });
-
-        it("anything else then string will be returned unmodified", function () {
-            expect(MultiIni.filters.uppercase(false)).to.equal(false);
-        });
+  describe("uppercase", function () {
+    it("is available", function () {
+      expect(MultiIni.filters.uppercase).to.be.defined;
     });
 
-    describe("trim", function () {
-        it("is available", function () {
-            expect(MultiIni.filters.trim).to.be.defined;
-        });
-
-        it("string should be trimmed", function () {
-            expect(MultiIni.filters.trim(' Test ')).to.equal('Test');
-        });
-
-        it("anything else then string will be returned unmodified", function () {
-            expect(MultiIni.filters.trim(false)).to.equal(false);
-        });
+    it("string should be uppercase", function () {
+      expect(MultiIni.filters.uppercase("Test")).to.equal("TEST");
     });
 
-    describe("constants", function () {
-        it("is available", function () {
-            expect(MultiIni.filters.constants).to.be.defined;
-        });
+    it("anything else then string will be returned unmodified", function () {
+      expect(MultiIni.filters.uppercase(false)).to.equal(false);
+    });
+  });
 
-        it("string should have replaced constants", function () {
-            const options = {constants: {CONSTANT: 'replaced'}};
-
-            expect(MultiIni.filters.constants('"Test " CONSTANT', options)).to.equal('"Test replaced"');
-            expect(MultiIni.filters.constants('"Test " CONSTANT " Test"', options)).to.equal('"Test replaced Test"');
-            expect(MultiIni.filters.constants('CONSTANT " Test"', options)).to.equal('"replaced Test"');
-        });
-
-        it("anything else then string will be returned unmodified", function () {
-            expect(MultiIni.filters.constants(false)).to.equal(false);
-        });
+  describe("trim", function () {
+    it("is available", function () {
+      expect(MultiIni.filters.trim).to.be.defined;
     });
 
-    describe("boolean", function () {
-        it("is available", function () {
-            expect(MultiIni.filters.boolean).to.be.defined;
-        });
-
-        it("string should have replaced booleans", function () {
-            // true
-            expect(MultiIni.filters.boolean('on')).to.equal(true);
-            expect(MultiIni.filters.boolean('On')).to.equal(true);
-            expect(MultiIni.filters.boolean('yes')).to.equal(true);
-            expect(MultiIni.filters.boolean('Yes')).to.equal(true);
-            expect(MultiIni.filters.boolean('true')).to.equal(true);
-            expect(MultiIni.filters.boolean('True')).to.equal(true);
-            expect(MultiIni.filters.boolean('TRUE')).to.equal(true);
-            // false 
-            expect(MultiIni.filters.boolean('off')).to.equal(false);
-            expect(MultiIni.filters.boolean('Off')).to.equal(false);
-            expect(MultiIni.filters.boolean('no')).to.equal(false);
-            expect(MultiIni.filters.boolean('No')).to.equal(false);
-            expect(MultiIni.filters.boolean('false')).to.equal(false);
-            expect(MultiIni.filters.boolean('False')).to.equal(false);
-            expect(MultiIni.filters.boolean('FALSE')).to.equal(false);
-            expect(MultiIni.filters.boolean('none')).to.equal(false);
-        });
-
-        it("anything else then string will be returned unmodified", function () {
-            expect(MultiIni.filters.boolean('test')).to.equal('test');
-            expect(MultiIni.filters.boolean(3)).to.equal(3);
-        });
+    it("string should be trimmed", function () {
+      expect(MultiIni.filters.trim(" Test ")).to.equal("Test");
     });
+
+    it("anything else then string will be returned unmodified", function () {
+      expect(MultiIni.filters.trim(false)).to.equal(false);
+    });
+  });
+
+  describe("constants", function () {
+    it("is available", function () {
+      expect(MultiIni.filters.constants).to.be.defined;
+    });
+
+    it("string should have replaced constants", function () {
+      const options = { constants: { CONSTANT: "replaced" } };
+
+      expect(MultiIni.filters.constants('"Test " CONSTANT', options)).to.equal(
+        '"Test replaced"'
+      );
+      expect(
+        MultiIni.filters.constants('"Test " CONSTANT " Test"', options)
+      ).to.equal('"Test replaced Test"');
+      expect(MultiIni.filters.constants('CONSTANT " Test"', options)).to.equal(
+        '"replaced Test"'
+      );
+    });
+
+    it("anything else then string will be returned unmodified", function () {
+      expect(MultiIni.filters.constants(false)).to.equal(false);
+    });
+  });
+
+  describe("boolean", function () {
+    it("is available", function () {
+      expect(MultiIni.filters.boolean).to.be.defined;
+    });
+
+    it("string should have replaced booleans", function () {
+      // true
+      expect(MultiIni.filters.boolean("on")).to.equal(true);
+      expect(MultiIni.filters.boolean("On")).to.equal(true);
+      expect(MultiIni.filters.boolean("yes")).to.equal(true);
+      expect(MultiIni.filters.boolean("Yes")).to.equal(true);
+      expect(MultiIni.filters.boolean("true")).to.equal(true);
+      expect(MultiIni.filters.boolean("True")).to.equal(true);
+      expect(MultiIni.filters.boolean("TRUE")).to.equal(true);
+      // false
+      expect(MultiIni.filters.boolean("off")).to.equal(false);
+      expect(MultiIni.filters.boolean("Off")).to.equal(false);
+      expect(MultiIni.filters.boolean("no")).to.equal(false);
+      expect(MultiIni.filters.boolean("No")).to.equal(false);
+      expect(MultiIni.filters.boolean("false")).to.equal(false);
+      expect(MultiIni.filters.boolean("False")).to.equal(false);
+      expect(MultiIni.filters.boolean("FALSE")).to.equal(false);
+      expect(MultiIni.filters.boolean("none")).to.equal(false);
+    });
+
+    it("anything else then string will be returned unmodified", function () {
+      expect(MultiIni.filters.boolean("test")).to.equal("test");
+      expect(MultiIni.filters.boolean(3)).to.equal(3);
+    });
+  });
 });

--- a/test/parser_spec.js
+++ b/test/parser_spec.js
@@ -7,87 +7,78 @@ const expect = chai.expect;
 
 chai.use(sinonChai);
 
-describe("Testing parser", function () {
+describe('Testing parser', function () {
     var Parser = require('../src/parser');
 
-    it("Availability of the class", function () {
+    it('Availability of the class', function () {
         expect(Parser).not.to.be.undefined;
         expect(Parser).not.to.be.null;
     });
 
-    it("Instantiate with default params", function () {
+    it('Instantiate with default params', function () {
         var instance = new Parser();
 
         expect(instance).not.to.be.null;
     });
 
-    describe("getKeyValue", function () {
-        var instance = new Parser({keep_quotes: true});
+    describe('getKeyValue', function () {
+        var instance = new Parser({ keep_quotes: true });
 
-        it("Returning key value not matching", function () {
+        it('Returning key value not matching', function () {
             var wrapper = function () {
-                instance.getKeyValue("key");
+                instance.getKeyValue('key');
             };
 
             expect(wrapper).to.throw;
         });
     });
 
-    describe("getMultiKeyValue", function () {
-        var instance = new Parser({keep_quotes: true});
+    describe('getMultiKeyValue', function () {
+        var instance = new Parser({ keep_quotes: true });
 
-        it("Returning key value not matching", function () {
+        it('Returning key value not matching', function () {
             var wrapper = function () {
-                instance.getMultiKeyValue("")
+                instance.getMultiKeyValue('');
             };
 
             expect(wrapper).to.throw;
         });
     });
 
-    describe("getMultiLineEndValue", function () {
-        var instance = new Parser({keep_quotes: true});
+    describe('getMultiLineEndValue', function () {
+        var instance = new Parser({ keep_quotes: true });
 
-        it("Returning key value not matching", function () {
+        it('Returning key value not matching', function () {
             var wrapper = function () {
-                instance.getMultiLineEndValue("")
+                instance.getMultiLineEndValue('');
             };
 
             expect(wrapper).to.throw;
         });
     });
 
-    describe("handleSection", function () {
-        var instance = new Parser({keep_quotes: true});
-        it("Same section appears twice", function () {
-            var ctx = {ini: {}};
+    describe('handleSection', function () {
+        var instance = new Parser({ keep_quotes: true });
+        it('Same section appears twice', function () {
+            var ctx = { ini: {} };
 
-            instance.handleSection(ctx, "[multi]");
-            instance.handleSection(ctx, "[another]");
-            instance.handleSection(ctx, "[multi]");
+            instance.handleSection(ctx, '[multi]');
+            instance.handleSection(ctx, '[another]');
+            instance.handleSection(ctx, '[multi]');
 
             expect(ctx.ini.multi).to.be.defined;
             expect(ctx.ini.another).to.be.defined;
             expect(ctx.current).to.equal(ctx.ini.multi);
         });
 
-        it("Section inherits from other section", function () {
-            var ctx = {ini: {}};
+        it('Section inherits from other section', function () {
+            var ctx = { ini: {} };
 
-            instance.handleSection(ctx, "[parent]");
-            instance.handleSection(ctx, "[child:parent]");
+            instance.handleSection(ctx, '[parent]');
+            instance.handleSection(ctx, '[child:parent]');
 
             expect(ctx.ini.parent).to.be.defined;
             expect(ctx.ini.child).to.be.defined;
         });
     });
-
-    describe("handleSingleLine", function () {
-        var instance = new Parser({keep_quotes: true});
-
-        it("", function () {
-
-        });
-    });
-
 });

--- a/test/security.js
+++ b/test/security.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const expect = chai.expect;
+
+chai.use(sinonChai);
+
+describe('Testing security', function () {
+    const MultiIni = require('../src/multi-ini-class');
+
+    it('Secure keys to fix prototype pollution', function () {
+        var ini = new MultiIni();
+
+        var data = ini.read('test/data/prototype_pollution.ini');
+
+        expect(data).not.to.be.null;
+
+        expect(data['test']).to.be.defined;
+        expect(data['test']['value']).to.equal('key');
+
+        expect(data['__proto__']['polluted']).to.be.undefined;
+        expect({}.__proto__.polluted).to.be.undefined;
+        expect(typeof polluted).to.equal('undefined');
+
+        expect(data['__proto__']['path_polluted']).to.be.undefined;
+        expect({}.__proto__.path_polluted).to.be.undefined;
+        expect(typeof path_polluted).to.equal('undefined');
+
+        console.log(data);
+    });
+});


### PR DESCRIPTION
Fixed prototype pollution by ignoring `__proto__` in sections and keys.

Steps to reproduce
payload.ini
```ini
[__proto__]
polluted = "polluted"
```

poc.js:
```js
var ini = require('multi-ini')

var parsed = ini.read('./payload.toml', { encoding: 'utf8' })
console.log(parsed)
console.log(parsed.__proto__)
console.log({}.__proto__)
console.log(polluted)
```

```sh
> node poc.js
{}
{ polluted: 'polluted' }
{ polluted: 'polluted' }
polluted
```