### PR TITLE
Fixed quoting to be applied only for strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-ini",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "description": "An ini-file parser which supports multi line, multiple levels and arrays to get a maximum of compatibility with Zend config files.",
   "main": "lib/index.js",

--- a/src/serializer.js
+++ b/src/serializer.js
@@ -8,7 +8,6 @@ const defaults = {
     keep_quotes: false,
 };
 
-
 class Serializer {
     constructor(options = {}) {
         this.options = Object.assign({}, defaults, options);
@@ -38,37 +37,50 @@ class Serializer {
     }
 
     serialize(content) {
-        return _.reduce(content, (output, sectionContent, section) => {
-            output += `[${section}]` + Constants.line_breaks[this.options.line_breaks];
-            output += this.serializeContent(sectionContent, '');
-            return output;
-        }, '');
+        return _.reduce(
+            content,
+            (output, sectionContent, section) => {
+                output += `[${section}]` + Constants.line_breaks[this.options.line_breaks];
+                output += this.serializeContent(sectionContent, '');
+                return output;
+            },
+            '',
+        );
     }
 
     serializeContent(content, path) {
-        return _.reduce(content, (serialized, subContent, key) => {
-            if (_.isArray(subContent)) {
-                for (let value of subContent) {
-                    if (this.needToBeQuoted(value)) {
-                        value = `"${value}"`;
+        return _.reduce(
+            content,
+            (serialized, subContent, key) => {
+                if (_.isArray(subContent)) {
+                    for (let value of subContent) {
+                        if (this.needToBeQuoted(value)) {
+                            value = `"${value}"`;
+                        }
+
+                        serialized += `${path}${path.length > 0 ? '.' : ''}${key}[]=${value}${
+                            Constants.line_breaks[this.options.line_breaks]
+                        }`;
+                    }
+                } else if (_.isObject(subContent)) {
+                    serialized += this.serializeContent(
+                        subContent,
+                        `${path}${path.length > 0 ? '.' : ''}${key}`,
+                    );
+                } else {
+                    if (_.isString(subContent) && this.needToBeQuoted(subContent)) {
+                        subContent = `"${subContent}"`;
                     }
 
-                    serialized += path + (path.length > 0 ? '.' : '') + key + "[]=" + value + Constants.line_breaks[this.options.line_breaks];
-                }
-            }
-            else if (_.isObject(subContent)) {
-                serialized += this.serializeContent(subContent, path + (path.length > 0 ? '.' : '') + key);
-            }
-            else {
-                if (this.needToBeQuoted(subContent)) {
-                    subContent = `"${subContent}"`;
+                    serialized += `${path}${path.length > 0 ? '.' : ''}${key}=${subContent}${
+                        Constants.line_breaks[this.options.line_breaks]
+                    }`;
                 }
 
-                serialized += path + (path.length > 0 ? '.' : '') + key + "=" + subContent + Constants.line_breaks[this.options.line_breaks];
-            }
-
-            return serialized;
-        }, '');
+                return serialized;
+            },
+            '',
+        );
     }
 }
 

--- a/test/serializer_spec.js
+++ b/test/serializer_spec.js
@@ -20,25 +20,42 @@ describe('Testing serializer', function () {
 
         expect(instance).not.to.be.null;
     });
-    
-    it('serialize should return a correct string with quoted keys', function () {
-       var instance = new Serializer();
 
-        expect(instance.serialize({
-            production: {
-                key: 'value'
-            }
-        })).to.be.equal('[production]\nkey="value"\n');
+    it('serialize should return a correct string with quoted keys', function () {
+        var instance = new Serializer();
+
+        expect(
+            instance.serialize({
+                production: {
+                    key: 'value',
+                },
+            }),
+        ).to.be.equal('[production]\nkey="value"\n');
     });
 
     it('serialize with keep_quotes should return a correct string with and without quotes', function () {
-        var instance = new Serializer({keep_quotes: true});
+        var instance = new Serializer({ keep_quotes: true });
 
-        expect(instance.serialize({
-            production: {
-                quoted: '"quoted"',
-                not_quoted: 'not_quoted'
-            }
-        })).to.be.equal('[production]\nquoted="quoted"\nnot_quoted=not_quoted\n');
+        expect(
+            instance.serialize({
+                production: {
+                    quoted: '"quoted"',
+                    not_quoted: 'not_quoted',
+                },
+            }),
+        ).to.be.equal('[production]\nquoted="quoted"\nnot_quoted=not_quoted\n');
+    });
+
+    it('Read multi line ini of issue #12 with windows line breaks', function () {
+        const data = {
+            root: {
+                anonMode: false,
+            },
+        };
+
+        const serializer = new Serializer();
+        const ini = serializer.serialize(data);
+
+        expect(ini).to.be.equal('[root]\nanonMode=false\n');
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "sourceMap": true,
+        "declaration": true,
+        "typeRoots": ["./node_modules/@types", "./types"],
+        "noImplicitAny": true,
+        "allowSyntheticDefaultImports": true,
+        "skipLibCheck": true,
+        "resolveJsonModule": true,
+        "lib": ["DOM", "ES6", "DOM.Iterable", "ScriptHost", "ES2019"],
+        "downlevelIteration": true,
+        "baseUrl": "./src",
+        "outDir": "./dist",
+        "rootDir": "./src"
+    },
+    "include": ["src/**/*"]
+}


### PR DESCRIPTION
Fixes an issue where a regexp is to be applied on a non string (boolean). Added a stricter check for strings.

Closes #48 